### PR TITLE
Updated addEventListener/removeEventListener method so they lower case event type

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -102,6 +102,7 @@ export default class Node {
      * @param {boolean} capturingPhase
      */
     addEventListener(eventType, listener, capturingPhase) {
+        eventType = eventType.toLowerCase();
         const _eventsKey = capturingPhase ? '_eventsCapturingPhase' : '_eventsBubblingPhase';
         if (!this[_eventsKey]) {
             this[_eventsKey] = new Map();
@@ -125,6 +126,7 @@ export default class Node {
      * @param {boolean} capturingPhase
      */
     removeEventListener(eventType, listener, capturingPhase) {
+        eventType = eventType.toLowerCase();
         const _eventsKey = capturingPhase ? '_eventsCapturingPhase' : '_eventsBubblingPhase';
         if (this[_eventsKey] && this[_eventsKey].has(eventType)) {
             let callbacks = this[_eventsKey].get(eventType);
@@ -158,7 +160,7 @@ export default class Node {
             const callbacks = this._eventsCapturingPhase && this._eventsCapturingPhase.get(event.type);
             if (callbacks) {
                 callbacks.some(function(callback) {
-                    callback();
+                    callback(event);
                     return event.immediatePropagationStopped;
                 });
             }
@@ -172,7 +174,7 @@ export default class Node {
                 const callbacks = this._eventsBubblingPhase && this._eventsBubblingPhase.get(event.type);
                 if (callbacks) {
                     callbacks.some(function(callback) {
-                        callback();
+                        callback(event);
                         return event.immediatePropagationStopped;
                     });
                 }

--- a/tests/src/Node.js
+++ b/tests/src/Node.js
@@ -4,6 +4,7 @@ import assert from 'proclaim';
 const lib = '../../lib/';
 
 const Document = require(lib + 'Document');
+const Event = require(lib + 'Event');
 
 test('Node attributes', () => {
     const document = new Document();
@@ -14,4 +15,56 @@ test('Node attributes', () => {
     assert.strictEqual(div.getAttribute('id'), 'testid');
     assert.isTrue(div.hasAttribute('id'));
     assert.strictEqual(div.outerHTML, '<div id="testid"></div>');
+});
+
+test('Node events attach', () => {
+    const document = new Document();
+    const div = document.createElement('div');
+    div.addEventListener('click', () => {}, true);
+    assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
+    assert.isTrue(div._eventsCapturingPhase.has('click'));
+    assert.strictEqual(div._eventsCapturingPhase.get('click').length,1);
+});
+
+test('Node events remove', () => {
+    const document = new Document();
+    const div = document.createElement('div');
+
+    function handler() {}
+
+    div.addEventListener('click', handler, true);
+    assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
+    assert.isTrue(div._eventsCapturingPhase.has('click'));
+    assert.strictEqual(div._eventsCapturingPhase.get('click').length,1);
+    div.removeEventListener('click', handler, true);
+    assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
+    assert.isTrue(div._eventsCapturingPhase.has('click'));
+    assert.strictEqual(div._eventsCapturingPhase.get('click').length,0);
+});
+
+test('Node events type normalize', () => {
+    const document = new Document();
+    const div = document.createElement('div');
+
+    function handler() {}
+
+    div.addEventListener('DOMLoadReady', handler, true);
+    assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
+    assert.isTrue(div._eventsCapturingPhase.has('domloadready'));
+});
+
+test('Node event dispatch', () => {
+    const document = new Document();
+    const div = document.createElement('div');
+    const event = new Event('DOMLoadReady');
+
+    function handler(e) {
+        assert.equal(e.type, 'domloadready');
+        assert.equal(e.target, div);
+    }
+
+    div.addEventListener('DOMLoadReady', handler, true);
+    assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
+    assert.isTrue(div._eventsCapturingPhase.has('domloadready'));
+    div.dispatchEvent(event);
 });

--- a/tests/src/Node.js
+++ b/tests/src/Node.js
@@ -23,7 +23,7 @@ test('Node events attach', () => {
     div.addEventListener('click', () => {}, true);
     assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
     assert.isTrue(div._eventsCapturingPhase.has('click'));
-    assert.strictEqual(div._eventsCapturingPhase.get('click').length,1);
+    assert.strictEqual(div._eventsCapturingPhase.get('click').length, 1);
 });
 
 test('Node events remove', () => {
@@ -35,11 +35,11 @@ test('Node events remove', () => {
     div.addEventListener('click', handler, true);
     assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
     assert.isTrue(div._eventsCapturingPhase.has('click'));
-    assert.strictEqual(div._eventsCapturingPhase.get('click').length,1);
+    assert.strictEqual(div._eventsCapturingPhase.get('click').length, 1);
     div.removeEventListener('click', handler, true);
     assert.isTrue(div.hasOwnProperty('_eventsCapturingPhase'));
     assert.isTrue(div._eventsCapturingPhase.has('click'));
-    assert.strictEqual(div._eventsCapturingPhase.get('click').length,0);
+    assert.strictEqual(div._eventsCapturingPhase.get('click').length, 0);
 });
 
 test('Node events type normalize', () => {


### PR DESCRIPTION
Provides compatibility with Event.type which is lowercased.
Added tests for usage example and covering.
Also add event object as first argument to event handlers like usual browser event handling.

Signed-off-by: Egor Bolgov <e.bolgov@semrush.com>